### PR TITLE
Handle runtime errors in worker

### DIFF
--- a/src/useWorker.js
+++ b/src/useWorker.js
@@ -66,6 +66,12 @@ export const useWorker = (fn, options = DEFAULT_OPTIONS) => {
           break
       }
     }
+
+    newWorker.onerror = e => {
+      promise.current[PROMISE_REJECT](e)
+      killWorker(ERROR)
+    }
+
     if (timeout) {
       timeoutId.current = setTimeout(() => {
         killWorker(TIMEOUT_EXPIRED)


### PR DESCRIPTION
Hey! This is my attempt to solve #21 

Previously, the callback was enclosed with a `Promise.resolve` which wasn't catching the errors that will possibly happen in callback. What I did instead was changing the `Promise.resolve` to a self invoked function that returns a new Promise, and chained the promise handlers there.

As a side note, a function declaration and a subsequent call is arguably more readable but added the IIFE instead to match how the `createWorkerBlobUrl` was written.

Let me know what you think! @alewin 

**OBS:** If the error is not handled in the client's code, this error is displayed in the console: `net::ERR_FILE_NOT_FOUND`.  Seems to be caused by this call `URL.revokeObjectURL(worker.current._url)` in `killWorker` but not sure of why it's different from normally calling `killWorker`.