### PR TITLE
[Types] Inherit argument and return type of original function passed to useWorker

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,5 +2,5 @@ export type HookOptions = {
   timeout?: number;
   dependencies?: Array<String>;
 }
-export type HookReturnType<T> = [(...fnArgs: Parameters<T>) => (Promise<ReturnType<T>>), string, () => void];
+export type HookReturnType<T extends Function> = [(...fnArgs: Parameters<T>) => (Promise<ReturnType<T>>), string, () => void];
 export function useWorker<T extends Function>(fn: T, options?: HookOptions): HookReturnType<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,5 +2,5 @@ export type HookOptions = {
   timeout?: number;
   dependencies?: Array<String>;
 }
-export type HookReturnType = [(...fnArgs: any[]) => (Promise<any>), string, () => void];
-export function useWorker(fn: Function, options?: HookOptions): HookReturnType;
+export type HookReturnType<T> = [(...fnArgs: Parameters<T>) => (Promise<ReturnType<T>>), string, () => void];
+export function useWorker<T>(fn: T, options?: HookOptions): HookReturnType<T>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,4 +3,4 @@ export type HookOptions = {
   dependencies?: Array<String>;
 }
 export type HookReturnType<T> = [(...fnArgs: Parameters<T>) => (Promise<ReturnType<T>>), string, () => void];
-export function useWorker<T>(fn: T, options?: HookOptions): HookReturnType<T>;
+export function useWorker<T extends Function>(fn: T, options?: HookOptions): HookReturnType<T>;


### PR DESCRIPTION
This ensures that `workerSumNumbers` keeps type definitions of `sumNumbers` in use case like this:

```ts
function sumNumbers(n1: number, n2: number) {
  return n1 + n2;
}

const [workerSumNumbers] = useWorker(sumNumbers);
```

`workerSumNumbers` will now have proper inherited type of 
```ts
const workerSumNumbers: (n1: number, n2: number) => Promise<number>
```