### PR TITLE
Feature/rename remote deps parser options

### DIFF
--- a/example/src/pages/ExternalScripts/index.js
+++ b/example/src/pages/ExternalScripts/index.js
@@ -17,7 +17,7 @@ function App() {
 
   const [sortWorker, { status: sortWorkerStatus, kill: killWorker }] = useWorker(sortDates, {
     autoTerminate: false, // you should manually kill the worker using "killWorker()"
-    dependencies: [
+    remoteDependencies: [
       "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js"
     ],
   });

--- a/src/lib/createWorkerBlobUrl.ts
+++ b/src/lib/createWorkerBlobUrl.ts
@@ -1,5 +1,5 @@
 import jobRunner from './jobRunner'
-import depsParser from './depsParser'
+import remoteDepsParser from './remoteDepsParser'
 
 /**
  * Converts the "fn" function into the syntax needed to be executed within a web worker
@@ -16,7 +16,7 @@ import depsParser from './depsParser'
  * .catch(postMessage(['ERROR', error])"
  */
 const createWorkerBlobUrl = (fn: Function, deps: string[]) => {
-  const blobCode = `${depsParser(deps)}; onmessage=(${jobRunner})(${fn})`
+  const blobCode = `${remoteDepsParser(deps)}; onmessage=(${jobRunner})(${fn})`
   const blob = new Blob([blobCode], { type: 'text/javascript' })
   const url = URL.createObjectURL(blob)
   return url

--- a/src/lib/remoteDepsParser.ts
+++ b/src/lib/remoteDepsParser.ts
@@ -1,6 +1,6 @@
 /**
  *
- * Concatenates the dependencies into a comma separated string.
+ * Concatenates the remote dependencies into a comma separated string.
  * this string will then be passed as an argument to the "importScripts" function
  *
  * @param {Array.<String>}} deps array of string
@@ -8,13 +8,13 @@
  * elements "deps" and "importScripts".
  *
  * @example
- * depsParser(['demo1', 'demo2']) // return importScripts('demo1, demo2')
+ * remoteDepsParser(['http://js.com/1.js', 'http://js.com/2.js']) // return importScripts('http://js.com/1.js, http://js.com/2.js')
  */
-const depsParser = (deps: string[]) => {
+const remoteDepsParser = (deps: string[]) => {
   if (deps.length === 0) return ''
 
   const depsString = (deps.map(dep => `${dep}`)).toString()
   return `importScripts('${depsString}')`
 }
 
-export default depsParser
+export default remoteDepsParser

--- a/src/useWorker.ts
+++ b/src/useWorker.ts
@@ -10,7 +10,7 @@ type WorkerController = {
 
 type Options = {
   timeout?: number;
-  dependencies?: string[];
+  remoteDependencies?: string[];
   autoTerminate?: boolean;
 }
 
@@ -18,7 +18,7 @@ const PROMISE_RESOLVE = 'resolve'
 const PROMISE_REJECT = 'reject'
 const DEFAULT_OPTIONS: Options = {
   timeout: undefined,
-  dependencies: [],
+  remoteDependencies: [],
   autoTerminate: true,
 }
 
@@ -65,11 +65,11 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
 
   const generateWorker = useDeepCallback(() => {
     const {
-      dependencies = DEFAULT_OPTIONS.dependencies,
+      remoteDependencies = DEFAULT_OPTIONS.remoteDependencies,
       timeout = DEFAULT_OPTIONS.timeout,
     } = options
 
-    const blobUrl = createWorkerBlobUrl(fn, dependencies!)
+    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!)
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
 

--- a/website/docs/examples/external.md
+++ b/website/docs/examples/external.md
@@ -25,7 +25,7 @@ title: External Scripts
 
   const [sortWorker, sortWorkerStatus, killWorker] = useWorker(sortDates, {
     timeout: 5000,
-    dependencies: [
+    remoteDependencies: [
       "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js"
     ]
   });

--- a/website/docs/useworker.md
+++ b/website/docs/useworker.md
@@ -35,16 +35,16 @@ to view the values of `WORKER_STATUS` click here: [Status API](./workerstatus.md
 import { useWorker } from "@koale/useworker";
 const [workerFn, workerStatus, workerTerminate] = useWorker(fn, {
   timeout: undefined,
-  dependencies: []
+  remoteDependencies: []
 });
 ```
 
 ## Options API
 
-| Value        | Type            | Default   | Description                                                               |
-| ------------ | --------------- | --------- | ------------------------------------------------------------------------- |
-| timeout      | Number          | undefined | the number of milliseconds before killing the worker                      |
-| dependencies | Array of String | []        | an array that contains the external dependencies needed to run the worker |
+| Value              | Type            | Default   | Description                                                               |
+| ------------------ | --------------- | --------- | ------------------------------------------------------------------------- |
+| timeout            | Number          | undefined | the number of milliseconds before killing the worker                      |
+| remoteDependencies | Array of String | []        | an array that contains the remote dependencies needed to run the worker   |
 
 ## Options Example
 
@@ -55,7 +55,7 @@ const fn = dates => dates.sort(dateFns.compareAsc)
 
 const [workerFn, workerStatus, workerTerminate] = useWorker(fn, {
   timeout: 50000 // 5 seconds
-  dependencies: [
+  remoteDependencies: [
       "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js" // dateFns
     ]
 });


### PR DESCRIPTION
This __break change__ will allow us to manage the names of the `options `of the "local" and "remote" `dependencies`.

**Proposal: Inline dependencies options** https://github.com/alewin/useWorker/issues/37