### PR TITLE
🐛 FIX: Logo dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <img height="200px" width="300px" src="logo.png" alt="useWorker"
+  <img width="300px" src="logo.png" alt="useWorker"
     title="useWorker() Use web workers with react hook" />
   <br>
 </h1>


### PR DESCRIPTION
Remove height from the logo to make it naturally resize itself to the right aspect ratio of the original image.