### PR TITLE
Feature: onCreate function

### DIFF
--- a/src/lib/createWorkerBlobUrl.ts
+++ b/src/lib/createWorkerBlobUrl.ts
@@ -1,6 +1,7 @@
 import { TRANSFERABLE_TYPE } from 'src/useWorker'
 import jobRunner from './jobRunner'
 import remoteDepsParser from './remoteDepsParser'
+import functionBodyParser from './functionBodyParser'
 
 /**
  * Converts the "fn" function into the syntax needed to be executed within a web worker
@@ -17,10 +18,11 @@ import remoteDepsParser from './remoteDepsParser'
  * .catch(postMessage(['ERROR', error])"
  */
 const createWorkerBlobUrl = (
-  fn: Function, deps: string[], transferable: TRANSFERABLE_TYPE,
+  fn: Function, deps: string[], transferable: TRANSFERABLE_TYPE, onCreate?: Function,
 ) => {
   const blobCode = `
     ${remoteDepsParser(deps)};
+    ${functionBodyParser(onCreate)};
     onmessage=(${jobRunner})({
       fn: (${fn}),
       transferable: '${transferable}'

--- a/src/lib/functionBodyParser.ts
+++ b/src/lib/functionBodyParser.ts
@@ -1,0 +1,22 @@
+/**
+ *
+ * Convert function to a string ang gets body expressions
+ * this expressions' strings will then executed on worker creation.
+ *
+ * @param {Array.<String>}} deps array of string
+ * @returns {String} a string composed by the concatenation of the array
+ * elements "deps" and "importScripts".
+ *
+ * @example
+ * functionBodyParser(function () {let a = 2}) // return let a = 2)
+ */
+const functionBodyParser = (fn?: Function) => {
+  const functionString = fn?.toString()
+
+  return functionString?.slice(
+    functionString.indexOf('{') + 1,
+    functionString.lastIndexOf('}')
+  )
+}
+
+export default functionBodyParser

--- a/src/lib/functionBodyParser.ts
+++ b/src/lib/functionBodyParser.ts
@@ -1,11 +1,10 @@
 /**
  *
  * Convert function to a string ang gets body expressions
- * this expressions' strings will then executed on worker creation.
+ * this expressions' strings will then be inserted in the worker blob
  *
- * @param {Array.<String>}} deps array of string
- * @returns {String} a string composed by the concatenation of the array
- * elements "deps" and "importScripts".
+ * @param {Function} [] A function whose will be extracted
+ * @returns {String} The function's body
  *
  * @example
  * functionBodyParser(function () {let a = 2}) // return let a = 2)

--- a/src/lib/functionBodyParser.ts
+++ b/src/lib/functionBodyParser.ts
@@ -9,7 +9,9 @@
  * @example
  * functionBodyParser(function () {let a = 2}) // return let a = 2)
  */
-const functionBodyParser = (fn?: Function) => {
+const functionBodyParser = (fn?: Function): string => {
+  if (!fn) return ''
+
   const functionString = fn?.toString()
 
   return functionString?.slice(

--- a/src/useWorker.ts
+++ b/src/useWorker.ts
@@ -18,6 +18,7 @@ type Options = {
   remoteDependencies?: string[];
   autoTerminate?: boolean;
   transferable?: TRANSFERABLE_TYPE;
+  onCreate?: Function,
 }
 
 const PROMISE_RESOLVE = 'resolve'
@@ -77,6 +78,7 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
       remoteDependencies = DEFAULT_OPTIONS.remoteDependencies,
       timeout = DEFAULT_OPTIONS.timeout,
       transferable = DEFAULT_OPTIONS.transferable,
+      onCreate,
     } = options
 
     const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable!)

--- a/src/useWorker.ts
+++ b/src/useWorker.ts
@@ -81,7 +81,7 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
       onCreate,
     } = options
 
-    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable!)
+    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable!, onCreate)
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
 


### PR DESCRIPTION
Based on the discussion on #43, I added a new field to the API. It's called `onCreate` (help with naming is appreciated 😅). 

### Description

We introduce a new `onCreate` field to the options object. `onCreate` will be a function whose body is intended to be evaluated once when the worker is created.

The  _body_ of the function is extracted as a string and added to the worker blob after the `importScripts` string. So we have every dependency available in the `onCreate` body.

The reason it's not just called but the body is extracted as a string is because we want to make the function body available in the global scope of the worker. This way, the expressions in the body are evaluated when the worker is created, and the scope of every variable evaluated will be the global worker scope, which is persisted through the whole life of the worker.

This API is expected to be used with `autoTerminate: false` but not restricted to it. Should we restrict it? Will there be any use case where this will be needed?

### Why

If we set global variables on the worker creation, we can reuse them on subsequent calls to the worker, avoiding otherwise potentially expensive re-declarations. The section below provides an example with the [fuse.js](https://fusejs.io/) library.

### Usage

```js
// Here, we instantiate the (expensive) Fuse class once, on creation.
// We also pass arguments to the constructor
const onCreate = () => {
  const list = ["hi", "bye", "what", "main thread"];
  const options = { isCaseSensitive: true }
  // eslint-disable-next-line no-undef
  const fuse = new Fuse(list, options);
  console.log('Called once on creation!')
};

const fuseSearch = ({ input }) => {
  // Now we have access to the variables declared on the `onCreate` method.
  // eslint-disable-next-line no-undef
  return fuse.search(input);
};

const [fuseWorker, { kill }] = useWorker(fuseSearch, {
  onCreate,
  remoteDependencies: ["https://cdn.jsdelivr.net/npm/fuse.js@5.2.3"],
  autoTerminate: false,
});

const callWorker = async () => {
  const res = await fuseWorker({ input: "i" });
  console.log(res);
};

useEffect(() => () => kill(), []);
```

In the example above, we also kept `options` and `list` on the global worker scope. Which may or not be useful. However, the general availability of declaring global variables enables all sorts of variations of similar patterns.

Let me know your thoughts! 