### PR TITLE
Local dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ More examples: https://github.com/alewin/useWorker/tree/develop/example
 - [x] Kill Web Worker
 - [x] Reactive web worker status
 - [x] Add timeout option
-- [x] import and use remote script inside `useWorker` function
+- [x] Import and use remote script inside `useWorker` function
 - [x] support [Transferable Objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable)
-- [ ] Testing useWorker [#41](https://github.com/alewin/useWorker/issues/41)
-- [ ] import and use local script inside `useWorker` function [#37](https://github.com/alewin/useWorker/issues/37)
+- [x] Testing useWorker [#41](https://github.com/alewin/useWorker/issues/41)
+- [x] Import and use local script inside `useWorker` function [#37](https://github.com/alewin/useWorker/issues/37)
 - [ ] useWorkers Hook [#38](https://github.com/alewin/useWorker/issues/38)
 
 
@@ -165,7 +165,7 @@ The library is experimental so if you find a **bug** or would like to request a 
 
 ---
 
-## 💡 Similar Project
+## 💡 Similar Projects
 
 - [greenlet](https://github.com/developit/greenlet/)
 - [react-hooks-worker](https://github.com/dai-shi/react-hooks-worker)
@@ -175,7 +175,7 @@ The library is experimental so if you find a **bug** or would like to request a 
 ## 💻 Contributors
 
 - Thanks to:
-- [@gonzachr](https://github.com/gonzachr) 
+- [@zant](https://github.com/zant) 
 - [@IljaDaderko](https://github.com/IljaDaderko)
 - [@Pigotz](https://github.com/Pigotz)
 - [@z4o4z](https://github.com/z4o4z)

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The library is experimental so if you find a **bug** or would like to request a 
 - [@IljaDaderko](https://github.com/IljaDaderko)
 - [@Pigotz](https://github.com/Pigotz)
 - [@z4o4z](https://github.com/z4o4z)
+- [@101arrowz](https://github.com/101arrowz)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
   ],
   "dependencies": {
     "dequal": "^1.0.0",
-    "isoworker": "^0.1.0"
+    "isoworker": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "background"
   ],
   "dependencies": {
-    "dequal": "^1.0.0"
+    "dequal": "^1.0.0",
+    "isoworker": "^0.1.0"
   }
 }

--- a/src/lib/createWorkerBlobUrl.ts
+++ b/src/lib/createWorkerBlobUrl.ts
@@ -1,3 +1,4 @@
+import isoworker from 'isoworker'
 import { TRANSFERABLE_TYPE } from 'src/useWorker'
 import jobRunner from './jobRunner'
 import remoteDepsParser from './remoteDepsParser'
@@ -17,10 +18,15 @@ import remoteDepsParser from './remoteDepsParser'
  * .catch(postMessage(['ERROR', error])"
  */
 const createWorkerBlobUrl = (
-  fn: Function, deps: string[], transferable: TRANSFERABLE_TYPE,
+  fn: Function,
+  deps: string[],
+  transferable: TRANSFERABLE_TYPE,
+  localDeps: () => unknown[],
 ) => {
+  const [context] = isoworker.createContext(localDeps)
   const blobCode = `
     ${remoteDepsParser(deps)};
+    ${context}
     onmessage=(${jobRunner})({
       fn: (${fn}),
       transferable: '${transferable}'

--- a/src/useWorker.ts
+++ b/src/useWorker.ts
@@ -18,6 +18,7 @@ type Options = {
   remoteDependencies?: string[];
   autoTerminate?: boolean;
   transferable?: TRANSFERABLE_TYPE;
+  localDependencies?: () => unknown[];
 }
 
 const PROMISE_RESOLVE = 'resolve'
@@ -27,7 +28,9 @@ const DEFAULT_OPTIONS: Options = {
   remoteDependencies: [],
   autoTerminate: true,
   transferable: TRANSFERABLE_TYPE.AUTO,
+  localDependencies: () => [],
 }
+
 
 /**
  *
@@ -77,9 +80,10 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
       remoteDependencies = DEFAULT_OPTIONS.remoteDependencies,
       timeout = DEFAULT_OPTIONS.timeout,
       transferable = DEFAULT_OPTIONS.transferable,
+      localDependencies = DEFAULT_OPTIONS.localDependencies,
     } = options
 
-    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable!)
+    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable!, localDependencies!)
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
 

--- a/test/localDeps.test.js
+++ b/test/localDeps.test.js
@@ -2,9 +2,13 @@ import React from "react";
 import { useWorker } from "../dist/index";
 import { renderHook } from "@testing-library/react-hooks";
 
-it("Runs successfully", async () => {
-  const sum = (a, b) => a + b;
-  const { result } = renderHook(() => useWorker(sum));
+const adder = (a, b) => a + b;
+
+it("Return", async () => {
+  const sum = (a, b) => adder(a, b);
+  const { result } = renderHook(() =>
+    useWorker(sum, { localDependencies: () => [adder] })
+  );
   const [sumWorker] = result.current;
   const res = await sumWorker(1, 2);
   assert.equal(res, 3);

--- a/test/localDepsImport.test.js
+++ b/test/localDepsImport.test.js
@@ -1,10 +1,13 @@
 import React from "react";
 import { useWorker } from "../dist/index";
 import { renderHook } from "@testing-library/react-hooks";
+import { adder } from "./utils";
 
-it("Runs successfully", async () => {
-  const sum = (a, b) => a + b;
-  const { result } = renderHook(() => useWorker(sum));
+it("Return", async () => {
+  const sum = (a, b) => adder(a, b);
+  const { result } = renderHook(() =>
+    useWorker(sum, { localDependencies: () => [adder] })
+  );
   const [sumWorker] = result.current;
   const res = await sumWorker(1, 2);
   assert.equal(res, 3);

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,1 @@
+export const adder = (a, b) => a + b;

--- a/website/docs/useworker.md
+++ b/website/docs/useworker.md
@@ -43,6 +43,7 @@ to view the values of `WORKER_STATUS` click here: [Status API](./workerstatus.md
 | ------------------ | --------------- | --------- | ------------------------------------------------------------------------- |
 | timeout            | Number          | undefined | The number of milliseconds before killing the worker                      |
 | remoteDependencies | Array of String | []        | An array that contains the remote dependencies needed to run the worker   |
+| localDependencies  | Function of Array of String | () => []        | A function that returns an array that contains the local dependencies needed to run the worker   |
 | autoTerminate      | Boolean         | true      | Kill the worker once it's done (success or error)                         |
 | transferable       | String          | 'auto'    | Enable [Transferable Objects](https://developer.mozilla.org/en-US/docs/Web/API/Transferable), to disable it set transferable: 'none' |
 
@@ -50,6 +51,7 @@ to view the values of `WORKER_STATUS` click here: [Status API](./workerstatus.md
 
 ```javascript
 import { useWorker } from "@koale/useworker";
+import { adder } from './utils'
 
 const fn = dates => dates.sort(dateFns.compareAsc)
 
@@ -58,6 +60,19 @@ const [workerFn, {status: workerStatus, kill: workerTerminate }] = useWorker(fn,
   remoteDependencies: [
     "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.30.1/date_fns.js" // dateFns
   ],
+});
+```
+## Local Dependencies Example
+
+```javascript
+import { useWorker } from "@koale/useworker";
+import { expensiveAdder } from './utils'
+
+const fn = (a, b) => expensiveAdder(a,b) 
+
+const [workerFn, {status: workerStatus, kill: workerTerminate }] = useWorker(fn, {
+  timeout: 50000 // 5 seconds
+  localDependencies: () => [expensiveAdder] // we pass the local function to the worker
 });
 ```
 

--- a/website/docs/useworker.md
+++ b/website/docs/useworker.md
@@ -51,7 +51,6 @@ to view the values of `WORKER_STATUS` click here: [Status API](./workerstatus.md
 
 ```javascript
 import { useWorker } from "@koale/useworker";
-import { adder } from './utils'
 
 const fn = dates => dates.sort(dateFns.compareAsc)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,6 +4073,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isoworker@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/isoworker/-/isoworker-0.1.0.tgz#7100e5cf54df7b47f16c0837b6d710c91e5070a3"
+  integrity sha512-XvNQTgTkQRCsAZU9To6rox9f4aJtKGTNFZrOZM28EsRNtOQeQGaaqI/cVGZv4EN6HhwILU5lwOrvEWfP3/PUjQ==
+
 jest-worker@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,7 +4073,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isoworker@^0.1.0:
+isoworker@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/isoworker/-/isoworker-0.1.1.tgz#99e68e08c18300685695c5187c4adbffa14d254b"
   integrity sha512-25hcgGZlLh3bxF6/YNS5aw/dw2H7cna/30EvKhq6Hwwsd7gzkML6oo9XrBTpExihBVJX/8RanSXR6M4Ox5dQWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4074,9 +4074,9 @@ isobject@^3.0.0, isobject@^3.0.1:
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 isoworker@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/isoworker/-/isoworker-0.1.0.tgz#7100e5cf54df7b47f16c0837b6d710c91e5070a3"
-  integrity sha512-XvNQTgTkQRCsAZU9To6rox9f4aJtKGTNFZrOZM28EsRNtOQeQGaaqI/cVGZv4EN6HhwILU5lwOrvEWfP3/PUjQ==
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/isoworker/-/isoworker-0.1.1.tgz#99e68e08c18300685695c5187c4adbffa14d254b"
+  integrity sha512-25hcgGZlLh3bxF6/YNS5aw/dw2H7cna/30EvKhq6Hwwsd7gzkML6oo9XrBTpExihBVJX/8RanSXR6M4Ox5dQWA==
 
 jest-worker@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
A new (and better) implementation of #77 thanks to @101arrowz and his cool lib [isoworker](https://github.com/101arrowz/isoworker).

Improvements over previous implementation:
- Support for more primitives (classes, objects, symbols etc)
- No need to use an object to access the functions, just using them normally (great one)

This is how it looks:

```javascript
import { useWorker } from "@koale/useworker";
import { expensiveAdder } from './utils'

const fn = (a, b) => expensiveAdder(a,b) 

const [workerFn, {status: workerStatus, kill: workerTerminate }] = useWorker(fn, {
  timeout: 50000 // 5 seconds
  localDependencies: () => [expensiveAdder] // we pass the local function to the worker
});
```

I've updated the website and Readme with documentation regarding local deps, and also added some tests.