### PR TITLE
Move types to their own folder

### DIFF
--- a/packages/useWorker/src/lib/createWorkerBlobUrl.ts
+++ b/packages/useWorker/src/lib/createWorkerBlobUrl.ts
@@ -1,5 +1,5 @@
 // import isoworker from 'isoworker'
-import { TRANSFERABLE_TYPE } from '../useWorker'
+import { TRANSFERABLE_TYPE } from '../types'
 import jobRunner from './jobRunner'
 import remoteDepsParser from './remoteDepsParser'
 

--- a/packages/useWorker/src/lib/jobRunner.ts
+++ b/packages/useWorker/src/lib/jobRunner.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import { TRANSFERABLE_TYPE } from 'src/useWorker'
+import { TRANSFERABLE_TYPE } from '../types'
 
 interface JOB_RUNNER_OPTIONS {
   fn: Function,

--- a/packages/useWorker/src/types.ts
+++ b/packages/useWorker/src/types.ts
@@ -1,0 +1,19 @@
+import WORKER_STATUS from './lib/status'
+
+export enum TRANSFERABLE_TYPE {
+  AUTO = 'auto',
+  NONE = 'none',
+}
+
+export type WorkerController = {
+  status: WORKER_STATUS;
+  kill: Function;
+}
+
+export type Options = {
+  timeout?: number;
+  remoteDependencies?: string[];
+  autoTerminate?: boolean;
+  transferable?: TRANSFERABLE_TYPE;
+  // localDependencies?: () => unknown[];
+}

--- a/packages/useWorker/src/useWorker.ts
+++ b/packages/useWorker/src/useWorker.ts
@@ -1,25 +1,8 @@
 import React from 'react'
 import createWorkerBlobUrl from './lib/createWorkerBlobUrl'
-import WORKER_STATUS from './lib/status'
 import { useDeepCallback } from './hook/useDeepCallback'
-
-type WorkerController = {
-  status: WORKER_STATUS;
-  kill: Function;
-}
-
-export enum TRANSFERABLE_TYPE {
-  AUTO = 'auto',
-  NONE = 'none',
-}
-
-type Options = {
-  timeout?: number;
-  remoteDependencies?: string[];
-  autoTerminate?: boolean;
-  transferable?: TRANSFERABLE_TYPE;
-  // localDependencies?: () => unknown[];
-}
+import { Options, TRANSFERABLE_TYPE, WorkerController } from './types'
+import WORKER_STATUS from './lib/status'
 
 const PROMISE_RESOLVE = 'resolve'
 const PROMISE_REJECT = 'reject'
@@ -30,7 +13,6 @@ const DEFAULT_OPTIONS: Options = {
   transferable: TRANSFERABLE_TYPE.AUTO,
   // localDependencies: () => [],
 }
-
 
 /**
  *
@@ -83,7 +65,11 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
       // localDependencies = DEFAULT_OPTIONS.localDependencies,
     } = options
 
-    const blobUrl = createWorkerBlobUrl(fn, remoteDependencies!, transferable! /*, localDependencies!*/)
+    const blobUrl = createWorkerBlobUrl(
+      fn,
+      remoteDependencies!,
+      transferable! /* localDependencies! */,
+    )
     const newWorker: Worker & { _url?: string } = new Worker(blobUrl)
     newWorker._url = blobUrl
 


### PR DESCRIPTION
This PR fixes the following error:

<img width="530" alt="Screen Shot 2021-08-03 at 11 53 47" src="https://user-images.githubusercontent.com/13141462/128046970-11e8377a-eb26-4c3c-9c74-daaf25d219cb.png">

By moving types to their own folder
