### PR TITLE
feat: Support for string functions

### DIFF
--- a/packages/useWorker/src/lib/createWorkerBlobUrl.ts
+++ b/packages/useWorker/src/lib/createWorkerBlobUrl.ts
@@ -18,7 +18,7 @@ import remoteDepsParser from './remoteDepsParser'
  * .catch(postMessage(['ERROR', error])"
  */
 const createWorkerBlobUrl = (
-  fn: Function, deps: string[], transferable: TRANSFERABLE_TYPE, /* localDeps: () => unknown[], */
+  fn: Function | string, deps: string[], transferable: TRANSFERABLE_TYPE, /* localDeps: () => unknown[], */
 ) => {
   // const [context] = isoworker.createContext(localDeps)
   const blobCode = `

--- a/packages/useWorker/src/useWorker.ts
+++ b/packages/useWorker/src/useWorker.ts
@@ -38,7 +38,7 @@ const DEFAULT_OPTIONS: Options = {
  * @param {Object} options useWorker option params
  */
 export const useWorker = <T extends (...fnArgs: any[]) => any>(
-  fn: T, options: Options = DEFAULT_OPTIONS,
+  fn: T | string, options: Options = DEFAULT_OPTIONS,
 ) => {
   const [workerStatus, setWorkerStatus] = React.useState<WORKER_STATUS>(WORKER_STATUS.PENDING)
   const worker = React.useRef<Worker & { _url?: string }>()


### PR DESCRIPTION
If you use a function, after some construction and packaging tools are built, the context will be out of context, making it unusable.
Therefore, the method of passing in a string is added here to solve the problems caused by building and packaging.