### PR TITLE
Reject promises for workers that are about to be killed

### DIFF
--- a/packages/useWorker/src/index.ts
+++ b/packages/useWorker/src/index.ts
@@ -1,2 +1,3 @@
 export { useWorker } from './useWorker'
 export { WORKER_STATUS } from './lib/status'
+export { AbortError } from './lib/abortError'

--- a/packages/useWorker/src/lib/abortError.ts
+++ b/packages/useWorker/src/lib/abortError.ts
@@ -1,0 +1,6 @@
+export class AbortError extends Error {
+  constructor() {
+    super('Aborted')
+    this.name = 'AbortError'
+  }
+}


### PR DESCRIPTION
Currently the promises for workers that are killed are left dangling which is problematic because dangling promises can result in memory leaks and other bad outcomes. A simple way to avoid that is to reject the promise with a specific AbortError that the user can catch and handle as they please. This is also the approach that axios is using for example for the same case if you kill a request before it returns a response.