### PR TITLE
Mark worker as not running immediately after being killed

### DIFF
--- a/packages/useWorker/src/useWorker.ts
+++ b/packages/useWorker/src/useWorker.ts
@@ -55,6 +55,7 @@ export const useWorker = <T extends (...fnArgs: any[]) => any>(
       URL.revokeObjectURL(worker.current._url)
       promise.current = {}
       worker.current = undefined
+      isRunning.current = false
       window.clearTimeout(timeoutId.current)
     }
   }, [])


### PR DESCRIPTION
This change is necessary so that the client could kill a worker and then immediately start a new worker. Without this change `useWorker()` will error out and say that you can only run one instance at a time because the running status is not updated until the next render cycle. If we mark it as not running immediately then the client can immediately create a new worker without having to wait for that to happen.